### PR TITLE
Webpack Dev Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' node node_modules/.bin/mocha -r ts-node/register --reporter mochawesome 'tests/**/*.test.ts'",
     "build": "tsc debuggerstart.ts  --downlevelIteration --esModuleInterop --moduleResolution node --outDir debugger/",
     "start": "node debugger/debuggerstart.js",
-    "prestart": "npm run build"
+    "prestart": "npm run build",
+    "dev": "npx webpack serve --mode=development"
   },
   "author": "",
   "license": "ISC",
@@ -22,7 +23,7 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.1.2",
     "wabt": "^1.0.20",
-    "webpack": "^5.10.0"
+    "webpack": "^5.72.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",
@@ -31,6 +32,7 @@
     "@types/node": "^17.0.23",
     "chai": "^4.2.0",
     "mocha": "^9.2.2",
-    "webpack-cli": "^4.2.0"
+    "webpack-cli": "^4.2.0",
+    "webpack-dev-server": "^4.9.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,12 +10,17 @@ module.exports = {
       },
     ],
   },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'build'),
+    },
+  },
   devtool: 'inline-source-map',
   externals: {
     wabt: 'wabt'
   },
   resolve: {
-    extensions: ['.ts']
+    extensions: ['.ts', '.js']
   },
   output: {
     path: path.resolve(__dirname, "build"),


### PR DESCRIPTION
Adding webpack dev server. Will watch files for changes and recompile + reload page automatically. 

Starts in `build/index.html`.

This includes updating webpack version, but things sadly break (at least on my setup) after updating because of webpack cache. To get around this, delete `package.json` and `node_modules` and rerun `npm i`. 

After that, you should be able to run `npm run dev` in the command line and open the link it prints out. 