### PR TITLE
Fixing equalType to stop using pointer equality

### DIFF
--- a/compiler.ts
+++ b/compiler.ts
@@ -1,6 +1,7 @@
 import { Program, Stmt, Expr, Value, Class, VarInit, FunDef } from "./ir"
 import { Annotation, BinOp, Type, UniOp } from "./ast"
 import { APPLY, BOOL, createMethodName, makeWasmFunType, NONE, NUM } from "./utils";
+import { equalType } from "./type-check";
 
 export type GlobalEnv = {
   globals: Map<string, boolean>;
@@ -173,11 +174,11 @@ function codeGenExpr(expr: Expr<Annotation>, env: GlobalEnv): Array<string> {
       const argTyp = expr.a.type;
       const argStmts = codeGenValue(expr.arg, env);
       var callName = expr.name;
-      if (expr.name === "print" && argTyp === NUM) {
+      if (expr.name === "print" && equalType(argTyp, NUM)) {
         callName = "print_num";
-      } else if (expr.name === "print" && argTyp === BOOL) {
+      } else if (expr.name === "print" && equalType(argTyp, BOOL)) {
         callName = "print_bool";
-      } else if (expr.name === "print" && argTyp === NONE) {
+      } else if (expr.name === "print" && equalType(argTyp, NONE)) {
         callName = "print_none";
       }
       return argStmts.concat([`(call $${callName})`]);

--- a/type-check.ts
+++ b/type-check.ts
@@ -136,7 +136,7 @@ export function equalTypeParams(params1: Type[], params2: Type[]) : boolean {
 
 export function equalType(t1: Type, t2: Type) {
   return (
-    t1 === t2 ||
+    (t1.tag === t2.tag && (t1.tag === NUM.tag || t1.tag === BOOL.tag || t1.tag === NONE.tag)) ||
     (t1.tag === "class" && t2.tag === "class" && t1.name === t2.name) ||
     (t1.tag === "callable" && t2.tag === "callable" && equalCallable(t1, t2)) ||
     (t1.tag === "typevar" && t2.tag === "typevar" && t1.name === t2.name)
@@ -689,10 +689,9 @@ export function tcExpr(env: GlobalTypeEnv, locals: LocalTypeEnv, expr: Expr<Anno
       if (expr.name === "print") {
         const tArg = tcExpr(env, locals, expr.arg, SRC);
         
-        // [lisa] commented out for now because it's failing some hidden test
-        // if (tArg.a.type.tag !== "number" && tArg.a.type.tag !== "bool") {
-        //   throw new TypeCheckError(SRC, `print() expects types "int" or "bool" as the argument, got ${JSON.stringify(tArg.a.type.tag)}`, tArg.a, tArg.a.endLoc);
-        // }
+        if (!equalType(tArg.a.type, NUM) && !equalType(tArg.a.type, BOOL) && !equalType(tArg.a.type, NONE)) {
+           throw new TypeCheckError(SRC, `print() expects types "int" or "bool" or "none" as the argument, got ${JSON.stringify(tArg.a.type.tag)}`, tArg.a);
+        }
         return { ...expr, a: tArg.a, arg: tArg };
       } else if (env.functions.has(expr.name)) {
         const [[expectedArgTyp], retTyp] = env.functions.get(expr.name);


### PR DESCRIPTION
- Stop using pointer equality with NUM, BOOL and NONE constants in
  equalType. This makes things error prone and brittle.
- Use equalType to determine the type of the argument to the print
  builtin function.
- Adding back the type-checking for the argument to print using
  equalType and also allowing the argument to be NONE.

The above two changes fix the print built in not working in Generic
classes. This was happening because the Monomorphizer makes a deep copy
of the entire AST of the class when concretizing it which does not
preserve the pointer addresses of primitive type annotations like NUM,
BOOL and NONE. This caused the compiler to be unable to determine the
type of the argument to print.