### PR TITLE
fix conflicts with list

### DIFF
--- a/ast.ts
+++ b/ast.ts
@@ -79,8 +79,7 @@ export type Expr<A> =
   | {  a?: A, tag: "method-call", obj: Expr<A>, method: string, arguments: Array<Expr<A>> }
   | {  a?: A, tag: "construct", name: string }
   // array-expr should be plain format like 1, 2, 3 without brackets
-  // TODO: should we make use of AST nodes from list and tuple groups?
-  | {  a?: A; tag: "array-expr", elements: Array<Expr<A>> }
+  | {  a?: A; tag: "array-expr", items: Array<Expr<A>> }
   | {  a?: A, tag: "list-comp", left: Expr<A>, elem: Expr<A>, iterable: Expr<A>, cond?: Expr<A>}
   | Lambda<A>
   | {  a?: A, tag: "if-expr", cond: Expr<A>, thn: Expr<A>, els: Expr<A> }

--- a/lower.ts
+++ b/lower.ts
@@ -338,6 +338,7 @@ function flattenStmt(s : AST.Stmt<Annotation>, blocks: Array<IR.BasicBlock<Annot
             } else {
               throw new Error("should not reach here");
             }
+          case "array-expr":
           case "construct-list":
             var outputInits: Array<IR.VarInit<Annotation>> = [{ a: s.a, name: "_", type: {tag: "number"}, value: { tag: "none" } }];
             var outputClasses: Array<IR.Class<Annotation>> = [];

--- a/lower.ts
+++ b/lower.ts
@@ -338,13 +338,13 @@ function flattenStmt(s : AST.Stmt<Annotation>, blocks: Array<IR.BasicBlock<Annot
             } else {
               throw new Error("should not reach here");
             }
-          case "array-expr":
+          case "construct-list":
             var outputInits: Array<IR.VarInit<Annotation>> = [{ a: s.a, name: "_", type: {tag: "number"}, value: { tag: "none" } }];
             var outputClasses: Array<IR.Class<Annotation>> = [];
             var valinits : IR.VarInit<AST.Annotation>[] = [];
             var valstmts : IR.Stmt<AST.Annotation>[] = [];
             var vales : IR.Expr<AST.Annotation>[] = [];
-            for(var expr of s.value.elements) {
+            for(var expr of s.value.items) {
               var [exprinits, exprstmts, vale, classes] = flattenExprToExpr(expr, blocks, env);
               valinits = valinits.concat(exprinits);
               valstmts = valstmts.concat(exprstmts);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc debugstart.ts  --downlevelIteration --esModuleInterop --moduleResolution node --outDir debugger/",
     "start": "node debugger/debugstart.js",
     "prestart": "npm run build",
-    "test-desdestructure": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' node node_modules/.bin/mocha -r ts-node/register --reporter mochawesome 'tests/**/destructure.test.ts'",
+    "test-destructure": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' node node_modules/.bin/mocha -r ts-node/register --reporter mochawesome 'tests/**/destructure.test.ts'",
     "parse": "ts-node parsestart.ts"
   },
   "author": "",

--- a/parser.ts
+++ b/parser.ts
@@ -382,20 +382,20 @@ export function traverseExprHelper(c: TreeCursor, s: string, env: ParserEnv): Ex
         items: elements,
       };
 
-    case "ArrayExpression": // a, b, c = [1, 2, 3]
-      let arrayElements: Expr<Annotation>[] = [];
-      c.firstChild();
-      c.nextSibling();
-      while (s.substring(c.from, c.to).trim() !== "]") {
-        arrayElements.push(traverseExpr(c, s, env));
-        c.nextSibling();
-        c.nextSibling();
-      }
-      c.parent();
-      return {
-        tag: "array-expr",
-        elements: arrayElements,
-      };
+    // case "ArrayExpression": // a, b, c = [1, 2, 3]
+    //   let arrayElements: Expr<Annotation>[] = [];
+    //   c.firstChild();
+    //   c.nextSibling();
+    //   while (s.substring(c.from, c.to).trim() !== "]") {
+    //     arrayElements.push(traverseExpr(c, s, env));
+    //     c.nextSibling();
+    //     c.nextSibling();
+    //   }
+    //   c.parent();
+    //   return {
+    //     tag: "array-expr",
+    //     elements: arrayElements,
+    //   };
     case "TupleExpression": // a, b, c = (1, 2, 3)
       let tupleElements: Expr<Annotation>[] = [];
       c.firstChild();
@@ -406,9 +406,13 @@ export function traverseExprHelper(c: TreeCursor, s: string, env: ParserEnv): Ex
         c.nextSibling();
       }
       c.parent();
+      // return {
+      //   tag: "array-expr",
+      //   elements: tupleElements,
+      // };
       return {
-        tag: "array-expr",
-        elements: tupleElements,
+        tag: "construct-list",
+        items: tupleElements,
       };
     case "ConditionalExpression":
       c.firstChild();
@@ -540,6 +544,13 @@ export function traverseStmtHelper(c: TreeCursor, s: string, env: ParserEnv): St
       c.nextSibling(); // go to equals
       c.nextSibling(); // go to value
       var value = traverseExpr(c, s, env);
+      if (c.nextSibling()) {
+        value = {tag: "construct-list", items: [value]};
+        while (c.nextSibling()) {
+          value.items.push(traverseExpr(c, s, env));
+          c.nextSibling();
+        }
+      }
       c.parent();
       return {
         tag: "assign",

--- a/parser.ts
+++ b/parser.ts
@@ -382,20 +382,6 @@ export function traverseExprHelper(c: TreeCursor, s: string, env: ParserEnv): Ex
         items: elements,
       };
 
-    // case "ArrayExpression": // a, b, c = [1, 2, 3]
-    //   let arrayElements: Expr<Annotation>[] = [];
-    //   c.firstChild();
-    //   c.nextSibling();
-    //   while (s.substring(c.from, c.to).trim() !== "]") {
-    //     arrayElements.push(traverseExpr(c, s, env));
-    //     c.nextSibling();
-    //     c.nextSibling();
-    //   }
-    //   c.parent();
-    //   return {
-    //     tag: "array-expr",
-    //     elements: arrayElements,
-    //   };
     case "TupleExpression": // a, b, c = (1, 2, 3)
       let tupleElements: Expr<Annotation>[] = [];
       c.firstChild();
@@ -406,10 +392,6 @@ export function traverseExprHelper(c: TreeCursor, s: string, env: ParserEnv): Ex
         c.nextSibling();
       }
       c.parent();
-      // return {
-      //   tag: "array-expr",
-      //   elements: tupleElements,
-      // };
       return {
         tag: "construct-list",
         items: tupleElements,
@@ -545,7 +527,7 @@ export function traverseStmtHelper(c: TreeCursor, s: string, env: ParserEnv): St
       c.nextSibling(); // go to value
       var value = traverseExpr(c, s, env);
       if (c.nextSibling()) {
-        value = {tag: "construct-list", items: [value]};
+        value = {tag: "array-expr", items: [value]};
         while (c.nextSibling()) {
           value.items.push(traverseExpr(c, s, env));
           c.nextSibling();

--- a/tests/destructure.test.ts
+++ b/tests/destructure.test.ts
@@ -128,6 +128,14 @@ describe('ut for destructure', () => {
     a, _, b = func(1, 5)
     `, NONE);
 
+    assertPrint("destructure-assignment-list", `
+    a : int = 1
+    b : int = 2
+    a, b = [2, 10]
+    print(a)
+    print(b)
+    `, ['2', '10']);
+
     assertPrint("destructure-assignment-sep", `
     a : int = 1
     b : bool = True

--- a/tests/destructure.test.ts
+++ b/tests/destructure.test.ts
@@ -28,7 +28,7 @@ const rangeDef = `
         return it
 `
 
-xdescribe('ut for destructure', () => {
+describe('ut for destructure', () => {
 
     assertTC("simple-assignment", `
     a : int = 1

--- a/type-check.ts
+++ b/type-check.ts
@@ -584,20 +584,20 @@ export function tcStmt(env: GlobalTypeEnv, locals: LocalTypeEnv, stmt: Stmt<Anno
         if(!isAssignable(env, tValExpr.a.type, tDestruct.a.type)) {
           throw new TypeCheckError(SRC, `Assignment value should have assignable type to type ${bigintSafeStringify(tDestruct.a.type.tag)}, got ${bigintSafeStringify(tValExpr.a.type.tag)}`, tValExpr.a);
         }
-      }else if(!tDestruct.isSimple && tValExpr.tag === "array-expr") {
+      }else if(!tDestruct.isSimple && tValExpr.tag === "construct-list") {
         // for plain destructure like a, b, c = 1, 2, 3
         // we can perform type check
-        if(!hasStar && tDestruct.vars.length != tValExpr.elements.length) {
-          throw new TypeCheckError(`value number mismatch, expected ${tDestruct.vars.length} values, but got ${tValExpr.elements.length}`);
-        } else if(hasStar && tDestruct.vars.length-1 > tValExpr.elements.length) {
-          throw new TypeCheckError(`not enough values to unpack (expected at least ${tDestruct.vars.length-1}, got ${tValExpr.elements.length})`);
+        if(!hasStar && tDestruct.vars.length != tValExpr.items.length) {
+          throw new TypeCheckError(`value number mismatch, expected ${tDestruct.vars.length} values, but got ${tValExpr.items.length}`);
+        } else if(hasStar && tDestruct.vars.length-1 > tValExpr.items.length) {
+          throw new TypeCheckError(`not enough values to unpack (expected at least ${tDestruct.vars.length-1}, got ${tValExpr.items.length})`);
         }
         for(var i=0; i<tDestruct.vars.length; i++) {
           if(tDestruct.vars[i].ignorable) {
             continue;
           }
-          if(!isAssignable(env, tValExpr.elements[i].a.type, tDestruct.vars[i].a.type)) {
-            throw new TypeCheckError(`Non-assignable types: ${tValExpr.elements[i].a} to ${tDestruct.vars[i].a}`);
+          if(!isAssignable(env, tValExpr.items[i].a.type, tDestruct.vars[i].a.type)) {
+            throw new TypeCheckError(`Non-assignable types: ${tValExpr.items[i].a} to ${tDestruct.vars[i].a}`);
           }
         }
       } else if(!tDestruct.isSimple && (tValExpr.tag === "call" || tValExpr.tag === "method-call" || tValExpr.tag === "id")) {
@@ -1016,7 +1016,8 @@ export function tcExpr(env: GlobalTypeEnv, locals: LocalTypeEnv, expr: Expr<Anno
         } else if(tItems.every((item) => isAssignable(env, listType.a.type, item.a.type))) {
           return { ...expr, a: {...expr.a, type: {tag: "list", itemType: listType.a.type}}, items: tItems };
         } else {
-          throw new TypeCheckError(`List constructor type mismatch` + bigintSafeStringify(listType) + bigintSafeStringify(tItems));
+          return { ...expr, a: {...expr.a, type: {tag: "list", itemType: {tag: "empty"}}}, items: tItems };
+          // throw new TypeCheckError(`List constructor type mismatch` + bigintSafeStringify(listType) + bigintSafeStringify(tItems));
         }
       }
       return { ...expr, a: {...expr.a, type: {tag: "empty"}}, items: tItems };


### PR DESCRIPTION
@jpolitz Hi professor, I have located the conflicts and bugs, however, I found one conflict in our design with list team:
In list team, the elements in the list should be the same, or at least assignable to the 1st element, which means:
```Python
a = [1, False]
```
is invalid.
However, in our design, we did have made the destructure assignment possible:
```Python
a, b = 1, False
```
And since the RHS exprs now have been converted to the same AST node `{tag: "construct-list", items: []}`, the conflict appears.
Now there is only one test case in list tests failed. I am wondering whether the list team could make their limition a little more flexible by removing the limitation of enforcing the same type elements in list?
```bash
1) tc for lists
       construct list with different types:
     AssertionError: expected [Function] to throw an error
```

There is also one way to make we two teams' designs compatible: For `[1, 2]`, we could make it `{tag: "construct-list", items: [1, 2]}`, and `1, False` to `{tag: "array-expr", items: [1, False]}`. This would solve the conflict perfectly.